### PR TITLE
add Survey.DD for ThinkPad_T61

### DIFF
--- a/Doc/Baremetal/Desktops/Dell/OptiPlex_790/Survey.DD
+++ b/Doc/Baremetal/Desktops/Dell/OptiPlex_790/Survey.DD
@@ -1,0 +1,76 @@
+$WW+H,1$Survey and System Results:
+
+OS: TinkerOS V5.200	04/03/26 02:57:08
+
+Current graphics mode: 640 x 480 (640 by 480 framebuffer)
+
+Current disk mode: AHCI
+
+Current boot drive: C
+
+Laptop: No
+
+Is AHCI mode supported in BIOS: Yes
+
+Is Legacy/IDE mode supported in BIOS: Yes
+
+Does PS/2 emulation of USB both keyboard and mouse work in TinkerOS: Yes
+
+Does your system have a PS/2 mouse or combo port: Yes
+
+Does your system have a serial port: Yes
+
+Does your system have a parallel port: No
+
+Can you install and run TinkerOS bare metal: Yes
+
+Can you install and run TempleOS bare metal: No
+
+Does PS/2 emulation of USB both keyboard and mouse work in TempleOS: Yes
+
+Is this a custom built PC / motherboard you installed: No
+
+Did the automatic installer work: No
+
+Did you manually partition and format the drive: Yes
+
+Did you manually have to enter IO port numbers: Yes
+
+Results from SysRepSurvey:
+
+SMBIOS version 2.6 (80 entries)
+$TR-C,"System"$
+$FD,3$$ID,3$Operating system:$FG,0$TinkerOS V5.200$FG$
+Manufacturer:$FG,0$Dell Inc.$FG$
+Product Name:$FG,0$OptiPlex 790$FG$
+Version:$FG,0$01$FG$
+$ID,-3$$TR-C,"Processor"$
+$FD,3$$ID,3$Socket Name:$FG,0$CPU 1$FG$
+Processor Type:$FG,0$Central Processor$FG$
+Status:$FG,0$Socket Populated, CPU Enabled$FG$
+Core Count:$FG,0$4$FG$
+Cores Enabled:$FG,0$4$FG$
+Manufacturer:$FG,0$Intel            $FG$
+Name:$FG,0$Intel(R) Core(TM) i5-2500 CPU @ 3.30GH         $FG$
+Family:$FG,0$6$FG$
+Model:$FG,0$10$FG$
+Stepping:$FG,0$7$FG$
+Current Speed:$FG,0$3.3 GHz$FG$
+Max Speed:$FG,0$4.0 GHz$FG$
+Socket:$FG,0$Other$FG$
+Voltage:$FG,0$0.0V$FG$
+External Clock:$FG,0$100 MHz$FG$
+$ID,-3$$TR-C,"Memory Array"$
+$FD,3$$ID,3$Location:$FG,0$Motherboard$FG$
+Use:$FG,0$System Memory$FG$
+Error Correction:$FG,0$None$FG$
+Max Capacity:$FG,0$32768 MB$FG$
+Mem Device Count:$FG,0$4$FG$
+$ID,-3$$FD,1$
+Hypervisor present: 0
+
+Detected resolution options:
+
+
+
+

--- a/Doc/Baremetal/Laptops/Lenovo/ThinkPad_T61/Survey.DD
+++ b/Doc/Baremetal/Laptops/Lenovo/ThinkPad_T61/Survey.DD
@@ -1,0 +1,98 @@
+$WW+H,1$Survey and System Results:
+
+OS: TinkerOS V5.200	01/04/26
+ 22:34:15
+
+Current graphics mode: 640 x 480 (640 by 480 framebuffer)
+
+Current disk mode: IDE/Legacy
+
+Current boot drive: C
+
+Laptop: Yes
+
+Dock with useful ports available: No
+
+Expresscard slot available: Unknown
+
+Do laptop keyboard and trackpad both work: Yes
+
+Is AHCI mode supported in BIOS: Yes
+
+Is Legacy/IDE mode supported in BIOS: Yes
+
+Does PS/2 emulation of USB both keyboard and mouse work in TinkerOS: Yes
+
+Does your system have a PS/2 mouse or combo port: Yes
+
+Does your system have a serial port: Yes
+
+Does your system have a parallel port: Yes
+
+Can you install and run TinkerOS bare metal: Yes
+
+Can you install and run TempleOS bare metal: No (Live CD only)
+
+Does PS/2 emulation of USB both keyboard and mouse work in TempleOS: Yes
+
+Is this a custom built PC / motherboard you installed: No
+
+Did the automatic installer work: No
+
+Did you manually partition and format the drive: Yes
+
+Did you manually have to enter IO port numbers: Yes
+
+Boot drive C IO port info:
+
+Base 0: 0x01f0
+Base 1: 0x03f4
+Unit  : 0
+
+Results from SysRepSurvey:
+
+SMBIOS version 2.4 (73 entries)
+$TR-C,"System"$
+$FD,3$$ID,3$Operating system:$FG,0$TinkerOS V5.200$FG$
+Manufacturer:$FG,0$LENOVO$FG$
+Product Name:$FG,0$7665Y1Y$FG$
+Version:$FG,0$ThinkPad T61$FG$
+$ID,-3$$TR-C,"Processor"$
+$FD,3$$ID,3$Socket Name:$FG,0$None$FG$
+Processor Type:$FG,0$Central Processor$FG$
+Status:$FG,0$Socket Populated, CPU Enabled$FG$
+Core Count:$FG,0$78$FG$
+Cores Enabled:$FG,0$111$FG$
+Manufacturer:$FG,0$GenuineIntel$FG$
+Name:$FG,0$Intel(R) Core(TM)2 Duo CPU     T7100  @ 1.80GHz$FG$
+Family:$FG,0$6$FG$
+Model:$FG,0$240$FG$
+Stepping:$FG,0$13$FG$
+Current Speed:$FG,0$1.8 GHz$FG$
+Max Speed:$FG,0$1.8 GHz$FG$
+Socket:$FG,0$None$FG$
+Voltage:$FG,0$1.3V$FG$
+External Clock:$FG,0$200 MHz$FG$
+$ID,-3$$TR-C,"Memory Array"$
+$FD,3$$ID,3$Location:$FG,0$Motherboard$FG$
+Use:$FG,0$System Memory$FG$
+Error Correction:$FG,0$None$FG$
+Max Capacity:$FG,0$4096 MB$FG$
+Mem Device Count:$FG,0$2$FG$
+$ID,-3$$FD,1$
+Hypervisor present: 0
+
+Detected resolution options:
+
+  320x200
+  640x480
+  800x600
+  1024x768
+  320x400
+  320x240
+  640x400
+  1280x800
+
+
+It appears clonezilla was used to partition the drive.
+


### PR DESCRIPTION
Device: Lenovo ThinkPad T61, Intel Core 2 Duo, 160GB HDD, Legacy BIOS, IDE/ATA mode enabled.
Installation: TempleOS bare metal failed - automated installer could not format the drive. TinkeroOS automated installer also failed at partition mount stage. Successfully installed manually using: DskPrt('C') → CopyTree("T:/","C:/") → BootHDIns('C') → BootMHDIns('C'). Had to select correct I/O port (0x01F0) manually, avoid probing loop by pressing 's' to skip.
Boot media: CD-R 700MB burned at 1x speed. DVD failed - drive could not read past boot sector.
Result: TinkeroOS V5.20 running successfully bare metal from HDD.
Notes: In memory of Terry A. Davis. Thank you to the TinkeroOS contributors for keeping this ecosystem alive. May TempleOS and TinkeroOS grow and endure.